### PR TITLE
Fixes for RISC OS build

### DIFF
--- a/build/makeROgcc
+++ b/build/makeROgcc
@@ -3,8 +3,8 @@
 CC = gcc
 LD = ld
 
-CFLAGS1 = -c -DDEBUG
-CFLAGS2 = -c
+CFLAGS1 = -w -c -DNONET -DDEBUG
+CFLAGS2 = -w -c -DNONET
 
 LDFLAGS1 =
 LDFLAGS2 =

--- a/src/brandy.c
+++ b/src/brandy.c
@@ -77,8 +77,14 @@ static struct loadlib {char *name; struct loadlib *next;} *liblist, *liblast;
 */
 
 int main(int argc, char *argv[]) {
+// Hmmm. Why doesn't this work?
+//#ifdef TARGET_RISCOS
+//  _kernel_oscli("WimpSlot 1600K");
+//#endif
   init1();
+#ifndef NONET
   brandynet_init();
+#endif
 #ifdef BRANDYAPP
    basicvars.runflags.quitatend = TRUE;
    basicvars.runflags.loadngo = TRUE;
@@ -175,6 +181,9 @@ static void gpio_init() {
   matrixflags.gpio = 0;				/* Initialise the flag to 0 (not enabled) */
   matrixflags.gpiomem = basicvars.offbase-1;	/* Initialise, will internally return &FFFFFFFF */
 #ifndef TARGET_MINGW
+#ifndef BODGEDJP
+#ifndef TARGET_RISCOS
+
   fd=open("/dev/gpiomem", O_RDWR | O_SYNC);
   if (fd == -1) return;				/* Couldn't open /dev/gpiomem - exit quietly */
 
@@ -187,6 +196,8 @@ static void gpio_init() {
   /* If we got here, mmap succeeded. */
   matrixflags.gpio = 1;
   matrixflags.gpiomemint=(uint32 *)matrixflags.gpiomem;
+#endif
+#endif
 #endif
   return;
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -564,7 +564,7 @@ static void invoke_editor(void) {
   basicvars.list_flags.lower = FALSE;   /* Changing keyword to lower case is useless here */
   basicvars.list_flags.expand = FALSE;  /* So is adding extra blanks */
   fhandle=secure_tmpnam(tempname);
-  if (!handle) {
+  if (!fhandle) {
     error(ERR_EDITFAIL, strerror (errno));
     return;
   }

--- a/src/riscos.c
+++ b/src/riscos.c
@@ -498,7 +498,7 @@ void emulate_gcol(int32 action, int32 colour, int32 tint) {
 ** to true if the graphics background colour is to be changed
 ** otherwise the foreground colour is altered
 */
-void emulate_gcolrgb(int32 action, int32 background, int32 red, int32 green, int32 blue) {
+int32 emulate_gcolrgb(int32 action, int32 background, int32 red, int32 green, int32 blue) {
   _kernel_oserror *oserror;
   _kernel_swi_regs regs;
   regs.r[0] = (blue << 24) + (green << 16) + (red << 8);
@@ -552,7 +552,7 @@ void emulate_mapcolour(int32 colour, int32 physcolour) {
 ** 'emulate_setcolour' handles the Basic 'COLOUR <red>,<green>,<blue>'
 ** statement
 */
-void emulate_setcolour(int32 background, int32 red, int32 green, int32 blue) {
+int32 emulate_setcolour(int32 background, int32 red, int32 green, int32 blue) {
   _kernel_oserror *oserror;
   _kernel_swi_regs regs;
   regs.r[0] = (blue << 24) + (green << 16) + (red << 8);


### PR DESCRIPTION
Various RISC OS functions had not had their declarations updated to match changed Windows/SDL declarations. Fixed, and now builds for RISC OS again.