### PR TITLE
Update to INKEY functions

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -747,7 +747,11 @@ void fn_false(void) {
 static void fn_get(void) {
   int ch;
   do {
-    ch=emulate_get() & 0xFF;
+#ifdef NEWKBD
+      ch=kbd_get() & 0xFF;
+#else
+      ch=emulate_get() & 0xFF;
+#endif
   } while (ch==0);
   push_int(ch);
 }
@@ -771,7 +775,11 @@ static void fn_getdol(void) {
   else {	/* Normal 'GET$' - Return character read as a string */
     cp = alloc_string(1);
     do {
+#ifdef NEWKBD
+      ch=kbd_get() & 0xFF;
+#else
       ch=emulate_get() & 0xFF;
+#endif
     } while (ch==0);
     *cp = ch;
     push_strtemp(1, cp);
@@ -783,7 +791,11 @@ static void fn_getdol(void) {
 ** OS_Byte 129 under a different name.
 */
 static void fn_inkey(void) {
+#ifdef NEWKBD
+  push_int(kbd_inkey(eval_intfactor()));
+#else
   push_int(emulate_inkey(eval_intfactor()));
+#endif
 }
 
 /*
@@ -794,7 +806,11 @@ static void fn_inkey(void) {
 static void fn_inkeydol(void) {
   int32 result;
   char *cp;
-  result = emulate_inkey(eval_intfactor());
+#ifdef NEWKBD
+  result=kbd_inkey(eval_intfactor());
+#else
+  result=emulate_inkey(eval_intfactor());
+#endif
   if (result == -1) {
     cp = alloc_string(0);
     push_strtemp(0, cp);

--- a/src/keyboard-inkey.h
+++ b/src/keyboard-inkey.h
@@ -32,13 +32,17 @@
 **                  mdfs.net/Software/BBCBasic/Testing/KeyScanWin.bbc to work out
 **                  what the exact values need to be. Documentation is huuugely vague.
 ** 03-Dec-2018 JGH: Tested and updated keys as marked. EN also covers US,CN,KO.
-**                  Probably impossible to get [ ] correct on non-JP keyboard layout.
+**                  Probably impossible to get [ ] correct on JP keyboard layout.
 **                  Some keys not visible through SDL: YEN \ KanaKeys, though they do
 **                  give keypresses to GET.
+** 09-Dec-2018 JGH: Added DOS/Windows VK keytable from JGH 'console' library.
 **
 */
+
+#ifdef USE_SDL
 #include "SDL.h"
 #include "SDL_keysym.h"
+#define KBD_SDL 1
 
 int32 inkeylookup[] = {
   SDLK_LSHIFT,		/*   0  done at a higher level */
@@ -87,7 +91,7 @@ int32 inkeylookup[] = {
   SDLK_KP9,		/*  43  Keypad 9      */
   SDLK_BREAK,		/*  44  Break         */
   SDLK_BACKQUOTE,	/*  45  `/~/?         EN:ok          JP:ok,locks */
-  SDLK_BACKSLASH,	/*  46  ?/Yen  #/~    EN:ok,SDL_5C   JP:ok,SLD_5C */
+  SDLK_BACKSLASH,	/*  46  UKP/Yen/etc   EN:ok,SDL_5C   JP:ok,SLD_5C */
   SDLK_BACKSPACE,	/*  47  Backspace     */
   SDLK_1,		/*  48  1             */
   SDLK_2,		/*  49  2             */
@@ -171,3 +175,144 @@ int32 inkeylookup[] = {
   SDLK_MENU,		/* 127  Windows Menu  */
   -1			/* 128  No key        */
 };
+#else
+
+#if defined(TARGET_DJGPP) || defined(TARGET_MINGW) || defined(TARGET_WIN32) || defined(TARGET_BCC32)
+#define KBD_PC 1
+#ifndef VK_SHIFT
+#include "keysym.h"
+#endif
+
+/* Lookup table from jgh 'console' library */
+unsigned char inkeylookup[]={
+VK_SHIFT,	/* -001  Shift        */
+VK_CONTROL,	/* -002  Ctrl         */
+VK_MENU,	/* -003  Alt          */
+VK_LSHIFT,	/* -004  Left Shift   */
+VK_LCONTROL,	/* -005  Left Ctrl    */
+VK_LMENU,	/* -006  Left Alt     */
+VK_RSHIFT,	/* -007  Right Shift  */
+VK_RCONTROL,	/* -008  Right Ctrl   */
+VK_RMENU,	/* -009  Right Alt    */
+VK_LBUTTON,	/* -010  Mouse Select */
+VK_RBUTTON,	/* -011  Mouse Menu   */
+VK_MBUTTON,	/* -012  Mouse Adjust */
+0,		/* -013  FN           */
+0,		/* -014               */
+0,		/* -015               */
+0,		/* -016               */
+'Q',		/* -017  Q            */
+'3',		/* -018  3            */
+'4',		/* -019  4            */
+'5',		/* -020  5            */
+VK_F4,		/* -021  F4           */
+'8',		/* -022  8            */
+VK_F7,		/* -023  F7           */
+0xbd,		/* -024  -            */
+0,		/* -025  ^            */
+VK_LEFT,	/* -026  Left         */
+VK_NUMPAD6,	/* -027  Keypad 6     */
+VK_NUMPAD7,	/* -028  Keypad 7     */
+VK_F11,		/* -029  F11          */
+VK_F12,		/* -030  F12          */
+VK_F10,		/* -031  F10          */
+VK_SCROLL,	/* -032  Scroll Lock  */
+VK_SNAPSHOT,	/* -033  F0/Print     */
+'W',		/* -034  W            */
+'E',		/* -035  E            */
+'T',		/* -036  T            */
+'7',		/* -037  7            */
+'I',		/* -038  I            */
+'9',		/* -039  9            */
+'0',		/* -040  0            */
+0xbd,		/* -041  _            */
+VK_DOWN,	/* -042  Down         */
+VK_NUMPAD8,	/* -043  Keypad 8     */
+VK_NUMPAD9,	/* -044  Keypad 9     */
+VK_PAUSE,	/* -045  Break        */
+0xdf,		/* -046  `/~/?        */
+0,		/* -047  UKP/Yen      */
+VK_BACK,	/* -048  Backspace    */
+'1',		/* -049  1            */
+'2',		/* -050  2            */
+'D',		/* -051  D            */
+'R',		/* -052  R            */
+'6',		/* -053  6            */
+'U',		/* -054  U            */
+'O',		/* -055  O            */
+'P',		/* -056  P            */
+0xdb,		/* -057  [            */
+VK_UP,		/* -058  Up           */
+VK_ADD,		/* -059  Keypad +     */
+VK_SUBTRACT,	/* -060  Keypad -     */
+VK_RETURN,	/* -061  Keypad Enter - same as Return */
+VK_INSERT,	/* -062  Insert       */
+VK_HOME,	/* -063  Home         */
+VK_PRIOR,	/* -064  PgUp         */
+VK_CAPITAL,	/* -065  Caps Lock    */
+'A',		/* -066  A            */
+'X',		/* -067  X            */
+'F',		/* -068  F            */
+'Y',		/* -069  Y            */
+'J',		/* -070  J            */
+'K',		/* -071  K            */
+0xc0,		/* -072  @            */
+0,		/* -073  :            */
+VK_RETURN,	/* -074  Return - Same as Keypad Enter */
+VK_DIVIDE,	/* -075  Keypad /     */
+VK_DECIMAL,	/* -076  Keypad Del   */
+VK_DECIMAL,	/* -077  Keypad .     */
+VK_NUMLOCK,	/* -078  Num Lock     */
+VK_NEXT,	/* -079  PgDn         */
+0xc0,		/* -080  '/"  '/@     */
+0,		/* -081  Shift Lock   */
+'S',		/* -082  S            */
+'C',		/* -083  C            */
+'G',		/* -084  G            */
+'H',		/* -085  H            */
+'N',		/* -086  N            */
+'L',		/* -087  L            */
+0xba,		/* -088  ;            */
+0xdd,		/* -089  ]            */
+VK_DELETE,	/* -090  Delete       */
+0xde,		/* -091  Keypad # #/~ */
+VK_MULTIPLY,	/* -092  Keypad *     */
+VK_SEPARATOR,	/* -093  Keypad ,     */
+0xbb,		/* -094  =/+          */
+0xdc,		/* -095  Left \ |     */
+0xe2,		/* -096  Right \ _    */
+VK_TAB,		/* -097  TAB          */
+'Z',		/* -098  Z            */
+' ',		/* -099  Space        */
+'V',		/* -100  V            */
+'B',		/* -101  B            */
+'M',		/* -102  M            */
+0xbc,		/* -103  ,            */
+0xbe,		/* -104  .            */
+0xbf,		/* -105  /            */
+VK_END,		/* -106  Copy/End     */
+VK_NUMPAD0,	/* -107  Keypad 0     */
+VK_NUMPAD1,	/* -108  Keypad 1     */
+VK_NUMPAD3,	/* -109  Keypad 3     */
+VK_NONCONVERT,	/* -110  NoConvert    */
+VK_CONVERT,	/* -111  Convert      */
+VK_KANA,	/* -112  Kana         */
+VK_ESCAPE,	/* -113  Escape       */
+VK_F1,		/* -114  F1           */
+VK_F2,		/* -115  F2           */
+VK_F3,		/* -116  F3           */
+VK_F5,		/* -117  F5           */
+VK_F6,		/* -118  F6           */
+VK_F8,		/* -119  F8           */
+VK_F9,		/* -120  F9           */
+0xdc,		/* -121  \ |          */
+VK_RIGHT,	/* -122  Right        */
+VK_NUMPAD4,	/* -123  Keypad 4     */
+VK_NUMPAD5,	/* -124  Keypad 5     */
+VK_NUMPAD2,	/* -125  Keypad 2     */
+VK_LWIN,	/* -126  WinLeft      */
+VK_RWIN,	/* -127  WinRight     */
+VK_APPS};	/* -128  WinMenu      */
+#endif
+
+#endif

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -285,6 +285,7 @@ int32 kbd_inkey(int32 arg) {
 
     if (arg < 128) {				/* Test for single keypress		*/
       switch (arg) {				/* Not visible from SDL keyscan		*/
+#ifdef TARGET_DOSWIN
         case 32:  return (GetAsyncKeyState(0x2C)<0 ? -1 : 0);		/* F0/PRINT	*/
         case 95:  return (GetAsyncKeyState(0xE2)<0 ||
 			  GetAsyncKeyState(0xC1)<0 ? -1 : 0);		/* Right \_	*/
@@ -296,10 +297,10 @@ int32 kbd_inkey(int32 arg) {
 
 						/* Exceptions from SDL keyscan		*/
         case 46:  return (keystate[0x5C] !=0 &&
-			  GetAsyncKeyState(0xDC) < 0  ? -1 : 0);	/* £/Y/etc	*/
+			  GetAsyncKeyState(0xDC) < 0  ? -1 : 0);	/* ?/Y/etc	*/
         case 90:  return (keystate[0x5C] !=0 &&
 			  GetAsyncKeyState(0xDC) == 0 ? -1 : 0);	/* K#  #~	*/
-
+#endif
 						/* Translate SDL keyscan		*/
         default:  return ((keystate[inkeylookup[arg]] != 0) ? -1 : 0);
       }
@@ -308,7 +309,7 @@ int32 kbd_inkey(int32 arg) {
     if (arg < 256) return -1;			/* Scan range - unimplemented		*/
 
     if ((arg & 0xFE00) == 0x0200) {		/* Direct API keyscan, INKEY(&FC00+nn)	*/
-      return (keystate[arg ^ 0x3FF] != 0) ? -1 : 0);
+      return ((keystate[arg ^ 0x3FF] != 0) ? -1 : 0);
     }
 
     return 0;					/* Anything else, return FALSE		*/
@@ -323,7 +324,7 @@ int32 kbd_inkey(int32 arg) {
 	/* Note: as a console app, this is the ID from when the program started		*/
         switch (arg) {
           case 24: return (GetAsyncKeyState(0xDE)<0 ? -1 : 0);	/* ^~      */
-          case 46: return (GetAsyncKeyState(0xDC)<0 ? -1 : 0);	/* £/Y/etc */
+          case 46: return (GetAsyncKeyState(0xDC)<0 ? -1 : 0);	/* ?/Y/etc */
           case 72: return (GetAsyncKeyState(0xBA)<0 ? -1 : 0);	/* :       */
           case 87: return (GetAsyncKeyState(0xBB)<0 ? -1 : 0);	/* ;       */
           case 90:						/* #~      */
@@ -360,6 +361,19 @@ int32 kbd_inkey(int32 arg) {
 }
 
 
+/* kbd_modkeys - fast read state of modifier keys */
+/* ---------------------------------------------- */
+/* Currently, only SHIFT tested by SDL for VDU paged scrolling */
+int32 kbd_modkeys(int32 arg) {
+#ifdef USE_SDL
+  if (keystate==NULL) return 0;				/* Not yet been initialised	*/
+  if (keystate[SDLK_LSHIFT] || keystate[SDLK_RSHIFT])	/* Either SHIFT key		*/
+    return -1;
+#endif
+  return 0;
+}
+
+
 #ifdef TARGET_DJGPP
 /* GetAsyncKeyState for DJGPP target */
 
@@ -383,7 +397,7 @@ int GetAsyncKeyState(int x) {
 
 /* kbd_get called to implement Basic GET and GET$ functions */
 /* -------------------------------------------------------- */
-int32 kbd_get() {
+int32 kbd_get(void) {
 
 #ifdef TARGET_RISCOS
   // RISC OS, pass directly to MOS
@@ -1339,6 +1353,7 @@ int32 emulate_inkey(int32 arg) {
 #endif
 
 /* This uses existing values of keystate and mousestate */
+/* This is only ever called to check for SHIFT key for paged scrolling */
 int32 emulate_inkey2(int32 arg) {
 #ifdef USE_SDL
   if (!keystate) return 0; /* Be nice if we've not called emulate_inkey earlier */

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -44,5 +44,7 @@ extern void set_escmul(int i);
 extern void osbyte44(int x);
 #ifdef NEWKBD
 extern int32 kbd_inkey(int32);
+extern int32 kbd_modkeys(int32);
+extern int32 kbd_get(void);
 #endif
 #endif

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -42,4 +42,7 @@ extern void checkforescape(void);
 extern void set_escint(int i);
 extern void set_escmul(int i);
 extern void osbyte44(int x);
+#ifdef NEWKBD
+extern int32 kbd_inkey(int32);
+#endif
 #endif

--- a/src/mos.c
+++ b/src/mos.c
@@ -32,8 +32,8 @@
 **	allow the use of these features to be silently ignored rather
 **	than flagging them and bringing the program to a halt. The
 **	results might not look pretty but the program will run.
-*/
-/*
+**
+**
 ** Crispian Daniels August 20th 2002:
 **	Included Mac OS X target in conditional compilation.
 **
@@ -1122,9 +1122,10 @@ static void cmd_cat(char *command) {
     FILE *sout;
     char buf;
 #ifdef TARGET_MINGW
-    sout = popen("dir", "r");
+    sout = popen("dir /w", "r");		// Impossible to get here?
 #else
     sout = popen("ls -l", "r");
+//  sout = popen("ls -C", "r");
 #endif
     if (sout == NULL) error(ERR_CMDFAIL);
     echo_off();
@@ -1359,8 +1360,6 @@ static void cmd_help(char *command)
 #endif
 		// NB: Adjust spaces in above to align version and date strings correctly
 
-///		emulate_printf("  Matrix Brandy Basic fork v%s.%s (%s)\r\n", BRANDY_MAJOR, BRANDY_MINOR, BRANDY_DATE);
-///		emulate_printf("  Fork of Brandy BASIC\r\n", BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL, BRANDY_DATE);
 	}
 	if (cmd == HELP_HOST || cmd == HELP_MOS) {
 		emulate_printf("  CD   <dir>\n\r  FX   <num>(,<num>(,<num>))\n\r");

--- a/src/target.h
+++ b/src/target.h
@@ -29,8 +29,9 @@
 
 #define BRANDY_MAJOR "1"
 #define BRANDY_MINOR "21"
-#define BRANDY_PATCHLEVEL "17"
 #define BRANDY_DATE  "05 Dec 2018"
+#define BRANDY_NAME  "Matrix"
+#define BRANDY_PATCHLEVEL "17"
 
 #ifndef __target_h
 #define __target_h
@@ -57,15 +58,15 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 ** coded here. This is the most important macro and is used to control
 ** the compilation of OS-specific parts of the program.
 **
-** BRANDY_OS is displayed by the startup and *HELP string
-** MACTYPE indicates the filing system type, returned by OSBYTE 0
+** BRANDY_OS is displayed by the startup and *HELP string.
+** MACTYPE indicates the system, returned by OSBYTE 0, and indicates the filing system type.
 **  0x0600 for directory.file/ext (eg RISC OS)
 **  0x0800 for directory/file.ext (eg UNIX)
 **  0x2000 for directory\file.ext (eg Win/DOS)
 ** OSVERSION indicates the host OS, returned by INKEY-256 and OSBYTE 129,-256.
 **  These values are made up, but see beebwiki.mdfs.net/OSBYTE_&81
 **
-** Name of editor invoked by Basic 'EDIT' command
+** Name of editor invoked by Basic 'EDIT' command.
 ** EDITOR_VARIABLE is the name of an environment variable that can be
 **		read to find the name of the editor to use.
 ** DEFAULT_EDITOR is the name of the editor to use if there is no
@@ -74,7 +75,7 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 ** Characters used to separate directories in names of files
 ** DIR_SEPS	is a string containing all the characters that can be
 ** 	    	be used to separate components of a file name (apart
-**		from the file name's extension)
+**		from the file name's extension).
 ** DIR_SEP	gives the character to be used to separate directory names.
 */
 
@@ -164,6 +165,7 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 
 #ifdef DJGPP
 #define TARGET_DJGPP
+#define TARGET_DOSWIN
 #define BRANDY_OS "DJGPP"
 #define OSVERSION 0xFA
 #define MACTYPE   0x2000
@@ -177,6 +179,7 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600 /* Require Win7 or later */
 #define TARGET_MINGW
+#define TARGET_DOSWIN
 #define BRANDY_OS "MinGW"
 #define OSVERSION 0xFC
 #define MACTYPE   0x2000
@@ -188,6 +191,7 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 
 #if defined(__LCC__) & defined(WIN32)
 #define TARGET_WIN32
+#define TARGET_DOSWIN
 #define BRANDY_OS "LCC-WIN32"
 #define OSVERSION 0xFC
 #define MACTYPE   0x2000
@@ -199,6 +203,7 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 
 #ifdef __BORLANDC__
 #define TARGET_BCC32
+#define TARGET_DOSWIN
 #define BRANDY_OS "BCC"
 #define OSVERSION 0xFC
 #define MACTYPE   0x2000
@@ -234,11 +239,21 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 #error Target operating system for interpreter is either missing or not supported
 #endif
 
-#ifdef USE_SDL
-#define IDSTRING "Matrix Brandy BASIC V version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL " (" BRANDY_OS "/SDL) " BRANDY_DATE
+#ifdef NEWKBD
+ #ifdef USE_SDL
+  #define SUFFIX "/SDL/NEWKBD) "
+ #else
+  #define SUFFIX "/NEWKBD) "
+ #endif
 #else
-#define IDSTRING "Matrix Brandy BASIC V version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL " (" BRANDY_OS ") " BRANDY_DATE
+ #ifdef USE_SDL
+  #define SUFFIX "/SDL) "
+ #else
+  #define SUFFIX ") "
+ #endif
 #endif
+
+#define IDSTRING "Matrix Brandy BASIC V version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL " (" BRANDY_OS SUFFIX BRANDY_DATE
 
 
 /*


### PR DESCRIPTION
I've been dragging a stiff comb through keyboard.c integrating all the
scattered code.

If NEWKBD is not defined it builds with the old keyboard handling code
and is functionally unchanged (and should be binary identical).

If NEWKBD is defined it builds with the new keyboard handling code.

All the platform-specific functions duplicate code which makes them more
appropriate to be single functions with bits of platform-specific code.
It also is gradually eliminating the BODGE identifiers I've had to put in
to get some of the builds working.

The majority of the INKEY code is now integrated and just depends on a
few bits of legacy code. Some of the legacy INKEY routines didn't even
support INKEY-256, so the first result was that all platforms support
INKEY-256 automatically.

+ve INKEY tested and works on: RISCOS:ok, WinSDL:ok, MGW:ok, DJP:ok
-ve INKEY tested and works on: RISCOS:ok, WinSDL:ok, MGW:ok, DJP:to do

The SDL builds now support testing for keys not known about by SDL by
using helper code for a handful of keyscan values.

DOS/Win builds without SDL now support negative INKEYs using code
from the JGH 'console' library.

