### PR TITLE
New makefile for Unix with plain/simple text

### DIFF
--- a/build/makefile.textNewKBD
+++ b/build/makefile.textNewKBD
@@ -1,0 +1,79 @@
+# Makefile for Brandy in text mode under NetBSD and Linux
+
+CC = gcc
+LD = gcc
+
+include git.mk
+
+#CFLAGS = -g -DDEBUG -I/usr/include/SDL -DUSE_ANSI -DDEFAULT_IGNORE -DNEWKBD -Wall $(GITFLAGS)
+#CFLAGS = -g -I/usr/include/SDL -DUSE_ANSI -DDEFAULT_IGNORE -DNEWKBD -Wall $(GITFLAGS)
+CFLAGS = -O2 -I/usr/include/SDL -DUSE_ANSI -DDEFAULT_IGNORE -DNEWKBD -Wall $(GITFLAGS)
+
+LDFLAGS +=
+
+LIBS = -lm
+
+SRCDIR = ../src
+
+OBJ = $(SRCDIR)/variables.o $(SRCDIR)/tokens.o \
+	$(SRCDIR)/strings.o $(SRCDIR)/statement.o $(SRCDIR)/stack.o \
+	$(SRCDIR)/miscprocs.o $(SRCDIR)/mainstate.o $(SRCDIR)/lvalue.o \
+	$(SRCDIR)/keyboard.o $(SRCDIR)/iostate.o $(SRCDIR)/heap.o \
+	$(SRCDIR)/functions.o $(SRCDIR)/fileio.o $(SRCDIR)/evaluate.o \
+	$(SRCDIR)/errors.o $(SRCDIR)/mos.o $(SRCDIR)/editor.o \
+	$(SRCDIR)/convert.o $(SRCDIR)/commands.o $(SRCDIR)/brandy.o \
+	$(SRCDIR)/assign.o $(SRCDIR)/net.o $(SRCDIR)/mos_sys.o
+
+TEXTONLYOBJ = $(SRCDIR)/textonly.o
+
+SIMPLETEXTOBJ = $(SRCDIR)/simpletext.o
+
+SRC = $(SRCDIR)/variables.c $(SRCDIR)/tokens.c \
+	$(SRCDIR)/strings.c $(SRCDIR)/statement.c $(SRCDIR)/stack.c \
+	$(SRCDIR)/miscprocs.c $(SRCDIR)/mainstate.c $(SRCDIR)/lvalue.c \
+	$(SRCDIR)/keyboard.c $(SRCDIR)/iostate.c $(SRCDIR)/heap.c \
+	$(SRCDIR)/functions.c $(SRCDIR)/fileio.c $(SRCDIR)/evaluate.c \
+	$(SRCDIR)/errors.c $(SRCDIR)/mos.c $(SRCDIR)/editor.c \
+	$(SRCDIR)/convert.c $(SRCDIR)/commands.c $(SRCDIR)/brandy.c \
+	$(SRCDIR)/assign.c $(SRCDIR)/net.c $(SRCDIR)/mos_sys.c
+
+TEXTONLYSRC = $(SRCDIR)/textonly.c
+
+SIMPLETEXTSRC = $(SRCDIR)/simpletext.c
+
+all:	tbrandy sbrandy
+
+tbrandy:	$(OBJ) $(TEXTONLYOBJ)
+	$(LD) $(LDFLAGS) -o tbrandy $(OBJ) $(TEXTONLYOBJ) $(LIBS)
+
+sbrandy:	$(OBJ) $(SIMPLETEXTOBJ)
+	$(LD) $(LDFLAGS) -o sbrandy $(OBJ) $(SIMPLETEXTOBJ) $(LIBS)
+
+include depends.mk
+
+.c.o:
+	$(CC) $(CFLAGS) $< -c -o $@
+
+trecompile:
+	$(CC) $(CFLAGS) $(SRC) $(TEXTONLYSRC) $(LIBS) -o tbrandy
+
+srecompile:
+	$(CC) $(CFLAGS) $(SRC) $(SIMPLETEXTSRC) $(LIBS) -o sbrandy
+
+tnodebug:
+	$(CC) $(CFLAGS2) $(SRC) $(TEXTONLYSRC) $(LIBS) -o tbrandy
+	strip tbrandy
+
+snodebug:
+	$(CC) $(CFLAGS2) $(SRC) $(SIMPLETEXTSRC) $(LIBS) -o sbrandy
+	strip sbrandy
+
+tcheck:
+	$(CC) $(CFLAGS) -Wall -O2 $(SRC) $(TEXTONLYSRC) $(LIBS) -o tbrandy
+
+scheck:
+	$(CC) $(CFLAGS) -Wall -O2 $(SRC) $(SIMPLETEXTSRC) $(LIBS) -o sbrandy
+
+clean:
+	rm -f $(SRCDIR)/*.o tbrandy sbrandy
+


### PR DESCRIPTION
Had to move the -DUSE_ANSI into the makefile so it is visible from other source files. tbrandy and sbrandy now building successfully, albeit with ANSI keys temporarily disabled. 