### PR TITLE
Add `--` command-line option

### DIFF
--- a/docs/use.txt
+++ b/docs/use.txt
@@ -124,6 +124,9 @@ where <filename> is the optional name of the program to load and
 			option allows some unsupported features that do not
 			affect the basic running of the program to be ignored.
 
+--			Subsequent options are passed to the Basic program, rather
+			than being considered as options to the interpreter.
+
 <filename>		Load and run the Basic program <filename>. Remain in
 			the interpreter when the program has finished running.
 

--- a/src/brandy.c
+++ b/src/brandy.c
@@ -282,6 +282,7 @@ static void init2(void) {
 ** for the Basic program
 */
 static void check_cmdline(int argc, char *argv[]) {
+  boolean had_double_dash = FALSE;
   int n;
   char optchar, *p;
 #ifndef BRANDYAPP
@@ -290,7 +291,7 @@ static void check_cmdline(int argc, char *argv[]) {
   n = 1;
   while (n<argc) {
     p = argv[n];
-    if (*p=='-') {	/* Got an option */
+    if (*p=='-' && !had_double_dash) {	/* Got an option */
       optchar = tolower(*(p+1));	/* Get first character of option name */
       if (optchar=='h') {		/* -help */
         show_help();
@@ -386,6 +387,8 @@ static void check_cmdline(int argc, char *argv[]) {
       }
       else if (optchar=='!')		/* -! - Don't initialise signal handlers */
         basicvars.misc_flags.trapexcp = FALSE;
+      else if (optchar=='-' && *(p+2) == 0)		/* -- - Pass all remaining options to the Basic program */
+        had_double_dash = TRUE;
       else {
 /* Any unrecognised options are assumed to be for the Basic program */
         add_arg(argv[n]);

--- a/src/errors.c
+++ b/src/errors.c
@@ -356,6 +356,7 @@ void show_help(void) {
 #else
   printf("  -ignore        Ignore 'unsupported feature' where possible\n");
 #endif
+  printf("  --             Subsequent options are passed to Basic program\n");
   printf("  <file>         Run Basic program <file> and leave interpreter when it ends\n\n");
 #ifdef HAVE_ZLIB_H
   printf("Basic program files may be gzipped.\n\n");


### PR DESCRIPTION
This is a common construct in other utilities, and indicates that any
subsequent arguments should not be consumed as options to the interpreter.
Since Brandy swallows all arguments that start (case-insensitively) with
the first one or two characters of options that it recognises, it is otherwise
impossible to correctly execute BASIC programs which themselves support
options which also match one of these patterns.

For example, a program can't have a `-quiet` option because it is confused
with `-quit`:

  brandy -chain MyProg -quiet
  No filename was supplied after option '-quiet'

but with this new facility, we can write:

  brandy -chain MyProg -- -quiet