### PR TITLE
Made fix to matrix-vector multiplication array routine

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -2825,7 +2825,7 @@ static void check_arraytype(basicarray *result, basicarray *lharray, basicarray 
   else if (rharray->dimcount == 1) {	/* Second array is a column vector (1st must be a matrix) */
     if (rhrows != lhcols) error(ERR_MATARRAY);
     result->dimcount = 1;		/* Result is a column vector the same size as the second array */
-    result->dimsize[ROW] = result->arrsize = rhrows;
+    result->dimsize[ROW] = result->arrsize = lhrows;
   }
   else {		/* Multiplying two two dimensional matrixes */
     if (lhcols != rhrows) error(ERR_MATARRAY);
@@ -2865,13 +2865,11 @@ static void eval_immul(void) {
       base[resindex] = sum;
     }
   }
-  else if (rharray->dimcount == 1) {	/* Result is a column vector */
+  else if (lharray->dimcount == 2 && rharray->dimcount == 1) {	/* Result is a column vector */
     for (resindex = 0; resindex < result.dimsize[ROW]; resindex++) {
-      int32 lhcol = 0;
       sum = 0;
       for (col = 0; col < rharray->dimsize[ROW]; col++) {
-        sum+=lhbase[lhcol] * rhbase[col];
-        lhcol++;
+        sum+=lhbase[lhrowsize * resindex + col] * rhbase[col];
       }
       base[resindex] = sum;
     }
@@ -2923,13 +2921,11 @@ static void eval_fmmul(void) {
       base[resindex] = sum;
     }
   }
-  else if (rharray->dimcount == 1) {	/* Result is a column vector */
+  else if (lharray->dimcount == 2 && rharray->dimcount == 1) {	/*  Result is a column vector */
     for (resindex = 0; resindex < result.dimsize[ROW]; resindex++) {
-      int32 lhcol = 0;
       sum = 0;
       for (col = 0; col < rharray->dimsize[ROW]; col++) {
-        sum += lhbase[lhcol] * rhbase[col];
-        lhcol++;
+        sum += lhbase[lhrowsize * resindex + col] * rhbase[col];
       }
       base[resindex] = sum;
     }


### PR DESCRIPTION
This is the fix for the issue I raised today.  I've tested it and it works well, but please preview my code as I am new to this library and very rusty on c programming.

Test code:
   10nr%=2
   20DIM vec(2)
   21vec(0)=1
   22vec(1)=2
   30DIM matrix(nr%,2)
   31matrix(0,0)=1
   32matrix(0,1)=2
   33matrix(1,0)=3
   34matrix(1,1)=4
   40DIM result(nr%)
   50result()=matrix().vec()
   60PRINTresult(0)
   70PRINTresult(1)

Should print 5,11, which it does.