### PR TITLE
Support for midipix

### DIFF
--- a/src/graphsdl.c
+++ b/src/graphsdl.c
@@ -38,7 +38,7 @@
 #include <math.h>
 #include "common.h"
 #include "target.h"
-#if defined(TARGET_UNIX) && !defined(TARGET_MACOSX)
+#if defined(TARGET_UNIX) && defined(USE_X11)
 #include <X11/Xlib.h>
 #endif
 #include "errors.h"
@@ -3876,7 +3876,7 @@ boolean init_screen(void) {
   pixfmt.alpha=255;
 #endif
 
-#if defined(TARGET_UNIX) && !defined(TARGET_MACOSX)
+#if defined(TARGET_UNIX) && defined(USE_X11)
   XInitThreads();
 #endif
 

--- a/src/mos_sys.c
+++ b/src/mos_sys.c
@@ -542,7 +542,7 @@ void mos_sys_ext(size_t swino, sysparm inregs[], size_t outregs[], int32 xflag, 
       /* Ugh, the UNIX struct is a different shape to the others! */
 #if defined(TARGET_MACOSX)
       outregs[7]=0;
-#elif defined(TARGET_UNIX)
+#elif defined(TARGET_UNIX) && defined(USE_X11)
       outregs[7]=(size_t)wmInfo.info.x11.window;
 #else
       outregs[7]=(size_t)wmInfo.window;

--- a/src/target.h
+++ b/src/target.h
@@ -208,6 +208,18 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 #define DIR_SEP  '/'
 #endif
 
+#ifdef __midipix__
+#define TARGET_MIDIPIX
+#define TARGET_UNIX
+#define BRANDY_OS "Midipix"
+#define LEGACY_OSVERSION 0xFD
+#define MACTYPE   0x0800
+#define EDITOR_VARIABLE "BRANDY_EDITOR"
+#define DEFAULT_EDITOR "vi"
+#define DIR_SEPS "/"
+#define DIR_SEP '/'
+#endif
+
 #ifdef __sun__
 #define TARGET_SUNOS
 #define TARGET_UNIX
@@ -352,6 +364,10 @@ typedef unsigned long long int uint64;	/* 64-bit unsigned integer */
 #define SFX2 "/ANSI"
 #else
 #define SFX2 ""
+#endif
+
+#if !defined(TARGET_MIDIPIX) && !defined(TARGET_MACOSX)
+#define USE_X11
 #endif
 
 #ifdef BRANDY_NODISPLAYOS


### PR DESCRIPTION
Midipix is a POSIX layer for Microsoft Windows much like Cygwin.

our port of SDL has GDI code-paths enabled for native win32 window support instead of relying on X11