### PR TITLE
Expand cmake configuration and do Windows test builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,11 +13,13 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cc }}
+      CFLAGS: "-Wextra"
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install libsdl1.2-dev
+      - run: sudo apt-get install libsdl1.2-dev valgrind
       - run: cmake .
-      - run: make
+      - run: cmake --build .
+      - run: ctest --rerun-failed --output-on-failure
   make:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -44,16 +46,87 @@ jobs:
       - uses: actions/checkout@v2
       - run: make -f ${{ matrix.makefile }}
       - run: make -f ${{ matrix.makefile }} test
-  make_macos:
+  cmake_macos:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['macos-14', 'macos-13']
-        makefile: ['build/makefile.macosx.text']
-    name: Compile via ${{ matrix.makefile }} Makefile on ${{ matrix.os }}
+        os: ['macos-latest', 'macos-13']
+    name: Compile via cmake on ${{ matrix.os }}
     env:
-      BRANDY_BUILD_FLAGS: "-Wextra"
+      CFLAGS: "-Wextra"
     steps:
       - uses: actions/checkout@v2
-      - run: make -f ${{ matrix.makefile }} all
-      - run: make -f ${{ matrix.makefile }} test
+      - run: cmake .
+      - run: cmake --build .
+      - run: ctest --rerun-failed --output-on-failure
+
+  cmake_windows:
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { icon: '🟦', sys: mingw64, runs-on: 'windows-latest' }
+          - { icon: '🟨', sys: ucrt64, runs-on: 'windows-latest' }
+          - { icon: '🟧', sys: clang64, runs-on: 'windows-latest' }
+# clangarm64 currently fails: https://github.com/llvm/llvm-project/issues/136358
+#          - { icon: '🟩', sys: clangarm64, runs-on: 'windows-11-arm' }
+    name: Compile via cmake on ${{ matrix.sys }}
+    env:
+      CFLAGS: "-Wextra"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - name: '${{ matrix.icon }} Setup MSYS2'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: >-
+            git
+            make
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+            dlfcn:p
+            sdl12-compat:p
+            perl:p
+      - run: cmake .
+      - run: cmake --build .
+      - run: ctest --rerun-failed --output-on-failure
+
+  docker-build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - linux/386
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/ppc64le
+          - linux/s390x
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          file: Dockerfile.sbrandy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.0.1)
-project(brandy)
+cmake_minimum_required(VERSION 3.19.0)
+project(brandy LANGUAGES C)
 
-set(BRANDY_USE_GRAPHICS ON CACHE BOOL "Use Graphics")
-set(BRANDY_USE_ANSI ON CACHE BOOL "Use ANSI Escape Sequences")
+add_compile_options(-Wall)
 
 set(SRCDIR src)
 set(SRC ${SRCDIR}/variables.c ${SRCDIR}/tokens.c ${SRCDIR}/strings.c
@@ -14,57 +13,102 @@ set(SRC ${SRCDIR}/variables.c ${SRCDIR}/tokens.c ${SRCDIR}/strings.c
 	${SRCDIR}/commands.c ${SRCDIR}/brandy.c ${SRCDIR}/assign.c
 	${SRCDIR}/net.c ${SRCDIR}/mos_sys.c)
 
-if(BRANDY_USE_GRAPHICS)
-	set(SRC ${SRC} ${SRCDIR}/graphsdl.c)
-	if(NOT WIN32)
-		find_package(X11 REQUIRED)
-		include_directories(${X11_INCLUDE_DIR})
-		link_libraries(${X11_LIBRARIES})
-	endif()
-	find_package(SDL REQUIRED)
-	include_directories(${SDL_INCLUDE_DIR})
-	link_libraries(${SDL_LIBRARY})
-	add_definitions(-DUSE_SDL)
-else()
-	if(BRANDY_USE_ANSI)
-		set(SRC ${SRC} ${SRCDIR}/textonly.c)
-	else()
-		set(SRC ${SRC} ${SRCDIR}/simpletext.c)
-	endif()
-	if (WIN32)
-		add_definitions(-DBODGEMGW)
-	endif()
-	add_definitions(-DNO_SDL)
-endif()
-if(WIN32)
-	link_libraries(wsock32 ws2_32)
-endif()
+add_executable(sbrandy ${SRC} ${SRCDIR}/simpletext.c)
+add_executable(tbrandy ${SRC} ${SRCDIR}/textonly.c)
 
-execute_process(
-  COMMAND git rev-parse --short HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+target_link_libraries(sbrandy m dl pthread)
+target_link_libraries(tbrandy m dl pthread)
 
-execute_process(
-  COMMAND git rev-parse --abbrev-ref HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_BRANCH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+install(TARGETS sbrandy DESTINATION bin)
+install(TARGETS tbrandy DESTINATION bin)
 
-execute_process(
-  COMMAND git log -1 --format=%cd
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_DATE
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
 
-add_definitions(-DBRANDY_GITCOMMIT=\"${GIT_COMMIT}\" -DBRANDY_GITBRANCH=\"${GIT_BRANCH}\" -DBRANDY_GITDATE=\"${GIT_DATE}\")
+find_package(SDL 1.2)
+# We want to request a version before 2, but cmake does not support version
+# ranges for SDL.
 
-add_definitions(-DDEFAULT_IGNORE)
-link_libraries(m)
-add_executable(brandy ${SRC})
-add_library(brandyapp ${SRC})
-target_compile_definitions(brandyapp PUBLIC -DBRANDYAPP)
+IF (SDL_FOUND)
+	add_executable(brandy ${SRC} ${SRCDIR}/graphsdl.c ${SRCDIR}/soundsdl.c)
+
+	target_link_libraries(brandy m dl pthread)
+	target_include_directories(brandy PRIVATE ${SDL_INCLUDE_DIRS})
+	target_link_libraries(brandy m dl pthread ${SDL_LIBRARIES})
+	target_compile_definitions(brandy PRIVATE -DUSE_SDL)
+
+	# libX11 may not be needed, eg., under Windows.
+	find_package(X11)
+	IF (X11_FOUND)
+		target_link_libraries(brandy ${X11_LIBRARIES})
+	ENDIF()
+
+	install(TARGETS brandy DESTINATION bin)
+ENDIF()
+
+IF (WIN32)
+	add_compile_definitions(-DCYGWINBUILD)
+	add_compile_definitions(-D__USE_MINGW_ANSI_STDIO)
+
+	target_link_libraries(sbrandy ws2_32 psapi)
+	target_link_libraries(tbrandy ws2_32 psapi)
+
+	IF (SDL_FOUND)
+		target_link_libraries(brandy ws2_32 psapi)
+	ENDIF()
+
+ENDIF()
+
+IF (LINUX)
+	target_link_libraries(sbrandy rt)
+	target_link_libraries(tbrandy rt)
+
+	IF (SDL_FOUND)
+		target_link_libraries(brandy rt)
+	ENDIF()
+ENDIF()
+
+# Inside "build-push-action" we have no .git. Rather than fighting, we put up
+# with it.
+IF (EXISTS .git)
+	execute_process(
+		COMMAND git rev-parse --short HEAD
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE GIT_COMMIT
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	execute_process(
+		COMMAND git rev-parse --abbrev-ref HEAD
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE GIT_BRANCH
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	execute_process(
+		COMMAND git log -1 --format=%cd
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_VARIABLE GIT_DATE
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	add_compile_definitions(-DBRANDY_GITCOMMIT=\"${GIT_COMMIT}\" -DBRANDY_GITBRANCH=\"${GIT_BRANCH}\" -DBRANDY_GITDATE=\"${GIT_DATE}\")
+ENDIF()
+
+# Do not throw an error on missing features.
+add_compile_definitions(DEFAULT_IGNORE)
+
+enable_testing()
+
+# Shebang does not work on msys2, running "prove" directly does not work.
+IF (WIN32)
+	find_program(PERL NAMES perl)
+	find_program(PROVE NAMES prove)
+
+	add_test(NAME Regressions COMMAND ${PERL} ${PROVE} --exec ${CMAKE_BINARY_DIR}/sbrandy -r t/)
+ELSE()
+	add_test(NAME Regressions COMMAND prove --exec ${CMAKE_BINARY_DIR}/sbrandy -r t/)
+
+	find_program(VALGRIND NAMES valgrind)
+	IF (VALGRIND)
+		add_test(NAME RegressionsValgrind COMMAND prove --exec "${VALGRIND} ${CMAKE_BINARY_DIR}/sbrandy" -r t/)
+	ENDIF()
+ENDIF()

--- a/Dockerfile.sbrandy
+++ b/Dockerfile.sbrandy
@@ -1,0 +1,11 @@
+FROM debian:12 AS build
+RUN apt-get update && apt-get install -y build-essential cmake
+COPY . /build
+WORKDIR /build
+RUN cmake .
+RUN cmake --build .
+RUN ctest
+
+FROM debian:12
+COPY --from=build /build/sbrandy /usr/local/bin/sbrandy
+ENTRYPOINT ["/usr/local/bin/sbrandy"]

--- a/src/net.c
+++ b/src/net.c
@@ -451,7 +451,11 @@ int checkfornewer() {
 #ifdef BRANDY_RELEASE
   snprintf(request, 1023, "GET /latest HTTP/1.0\r\nHost: brandy.matrixnetwork.co.uk\r\nUser-Agent: MatrixBrandy/" BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "(" BRANDY_OS "/" CPUTYPE SFX1 SFX2 ")\r\n\r\n");
 #else
+#ifdef BRANDY_GITCOMMIT
   snprintf(request, 1023, "GET /latest HTTP/1.0\r\nHost: brandy.matrixnetwork.co.uk\r\nUser-Agent: MatrixBrandy/" BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "(" BRANDY_OS "/" CPUTYPE SFX1 SFX2 " " BRANDY_GITBRANCH ":" BRANDY_GITCOMMIT ")\r\n\r\n");
+#else
+  snprintf(request, 1023, "GET /latest HTTP/1.0\r\nHost: brandy.matrixnetwork.co.uk\r\nUser-Agent: MatrixBrandy/" BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "(" BRANDY_OS "/" CPUTYPE SFX1 SFX2 ")\r\n\r\n");
+#endif
 #endif
   net_bputstr(hndl, request, -1);
   free(request);

--- a/src/target.h
+++ b/src/target.h
@@ -433,7 +433,11 @@ typedef unsigned long int nativeuint;   /* 32 or 64-bit depending on architectur
 #ifdef BRANDY_RELEASE
 #define IDSTRING "Matrix Brandy BASIC VI version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "-Release (" BRANDY_OS "/" CPUTYPE SFX1 SFX2 ") " BRANDY_DATE
 #else
+#ifdef BRANDY_GITCOMMIT
 #define IDSTRING "Matrix Brandy BASIC VI version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "+dev (" BRANDY_OS "/" CPUTYPE SFX1 SFX2 ") " BRANDY_DATE "\r\n\nDevelopment snapshot at git " BRANDY_GITBRANCH ":" BRANDY_GITCOMMIT " (" BRANDY_GITDATE ")"
+#else
+#define IDSTRING "Matrix Brandy BASIC VI version " BRANDY_MAJOR "." BRANDY_MINOR "." BRANDY_PATCHLEVEL "+dev (" BRANDY_OS "/" CPUTYPE SFX1 SFX2 ") " BRANDY_DATE "\r\n\nDevelopment snapshot"
+#endif
 #endif /* BRANDY_RELEASE */
 #endif /* BRANDY_NODISPLAYOS */
 


### PR DESCRIPTION
Hello,

This change expands the cmake configuration to build all three variants of MatrixBrandy. It now auto-detects SDL, and should get the various paths correct without specifying them manually.

Using this I have got it auto-building under Windows. Four msys2 environments are tested. I have also made use of Docker to build and on additional architectures (like 32 bit ARM.)

I would be tempted to deprecate the makefiles for cmake supported platforms rather than attempt to maintain the many variants.