### PR TITLE
Fix root-cause of the problem for issue 105 involving horizontal line drawing, and an array overflow potential issue.

### DIFF
--- a/src/graphsdl.c
+++ b/src/graphsdl.c
@@ -4103,8 +4103,6 @@ static void mode7renderscreen(void) {
 static void trace_edge(int32 x1, int32 y1, int32 x2, int32 y2) {
   int32 dx, dy, xf, yf, a, b, t, i;
 
-  if (x1 == x2 && y1 == y2) return;
-
   if (x2 > x1) {
     dx = x2 - x1;
     xf = 1;
@@ -4128,8 +4126,8 @@ static void trace_edge(int32 x1, int32 y1, int32 x2, int32 y2) {
     t = a - dx;
     b = t - dx;
     for (i = 0; i <= dx; i++) {
-      if (y1 >= 0 && x1 < geom_left[y1]) geom_left[y1] = x1;
-      if (y1 >= 0 && x1 > geom_right[y1]) geom_right[y1] = x1;
+      if (y1 >= 0 && y1<MAX_YRES && x1 < geom_left[y1]) geom_left[y1] = x1;
+      if (y1 >= 0 && y1<MAX_YRES && x1 > geom_right[y1]) geom_right[y1] = x1;
       x1 += xf;
       if (t < 0)
         t += a;
@@ -4144,8 +4142,8 @@ static void trace_edge(int32 x1, int32 y1, int32 x2, int32 y2) {
     t = a - dy;
     b = t - dy;
     for (i = 0; i <= dy; i++) {
-      if (y1 >= 0 && x1 < geom_left[y1]) geom_left[y1] = x1;
-      if (y1 >= 0 && x1 > geom_right[y1]) geom_right[y1] = x1;
+      if (y1 >= 0 && y1<MAX_YRES && x1 < geom_left[y1]) geom_left[y1] = x1;
+      if (y1 >= 0 && y1<MAX_YRES && x1 > geom_right[y1]) geom_right[y1] = x1;
       y1 += yf;
       if (t < 0)
         t += a;
@@ -4186,8 +4184,10 @@ static void buff_convex_poly(SDL_Surface *sr, int32 n, int32 *x, int32 *y, Uint3
     if (y[i] > high) high = y[i];
     if (y[i] < low) low = y[i];
   }
+  if (high>MAX_YRES-1) high=MAX_YRES-1;
+  if (low<0) low=0;
   /* reset the minimum amount of the edge tables */
-  for (iy = (low < 0) ? 0: low; iy <= high; iy++) {
+  for (iy = low; iy <= high; iy++) {
     geom_left[iy] = MAX_XRES + 1;
     geom_right[iy] = - 1;
   }


### PR DESCRIPTION
Fixed bug in trace_edge function.  It was exiting early if x1==x2&&y1==y2, and this early exit was causing geom_left/right not to be set.  But if x1=x2&&y1=y2, then there was no need to exit early as this function will correctly plot a single point. We don't want to exit early and lose this point.  

This fix should supercede commit 882c97 which is no longer needed.  I think I've fixed the root-cause of the problem for issue 105 involving horizontal line drawing.

Also this pull requests includes a fix to an array-out-of-bounds bug on the arrays geom_left[] and geom_right[].  There was no check on the index to this array exceeding the size of the array.  So to make that into a array-overflow bug, you'd just need to plot a triangle with a high y coordinate at the top of the triangle.  (Note that vertical clipping does not take place on the trace_edge function; so this would have resulted in an array-out-of-bounds bug)