### PR TITLE
Warning fixes

### DIFF
--- a/src/mainstate.c
+++ b/src/mainstate.c
@@ -1189,7 +1189,10 @@ void exec_for(void) {
   }
   basicvars.current++;
   switch (forvar.typeinfo) {    /* Assign control variable's initial value */
-  case VAR_UINT8: forvar.typeinfo = VAR_INTWORD;
+  case VAR_UINT8:
+    forvar.typeinfo = VAR_INTWORD;
+    *forvar.address.intaddr = pop_anynum32();
+    break;
   case VAR_INTWORD:
     *forvar.address.intaddr = pop_anynum32();
     break;

--- a/src/miscprocs.c
+++ b/src/miscprocs.c
@@ -403,14 +403,14 @@ static void strip(char line[]) {
 ** contains nothing
 */
 boolean read_line(char line[], int32 linelen) {
-  readstate result;
+  int32 result;
   line[0] = asc_NUL;
   result = kbd_readline(line, linelen, 0);
-  if (result==-READ_ESC || basicvars.escape) {
+  if (result==-1 || basicvars.escape) {
     error(ERR_ESCAPE);
     return FALSE;
   }
-  if (result==-READ_EOF) return FALSE;           /* Read failed - Hit EOF */
+  if (result==-2) return FALSE;           /* Read failed - Hit EOF */
   strip(line);
   return TRUE;
 }
@@ -426,13 +426,13 @@ boolean read_line(char line[], int32 linelen) {
 ** is prefilled with a string
 */
 boolean amend_line(char line[], int32 linelen) {
-  readstate result;
+  int32 result;
   result = kbd_readline(line, linelen,0);
-  if (result==-READ_ESC || basicvars.escape) {
+  if (result==-1 || basicvars.escape) {
     error(ERR_ESCAPE);
     return FALSE;
   }
-  if (result==-READ_EOF) return FALSE;           /* Read failed - Hit EOF */
+  if (result==-2) return FALSE;           /* Read failed - Hit EOF */
   strip(line);
   return TRUE;
 }

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -2458,8 +2458,8 @@ int32 reformat(byte *tp, byte *tokenbuf, int32 ftype) {
               } else {
                 p = twobyte_token[token2-ACORNTWO_LOWEST];      /* C8 8E+n */
                 tp++;
-                break;
               }
+              break;
             case ACORN_COMMAND:                                 /* C7 nn   */
               if (token2>ACORNCMD_HIGHEST) {
                 if((int32)(token2-ACORN_OTHER) < 0) {           /* Sanity check */
@@ -2474,8 +2474,8 @@ int32 reformat(byte *tp, byte *tokenbuf, int32 ftype) {
                   p = command_token[token-ACORNCMD_LOWEST];       /* C7 8E+n */
                 }
                 tp++;
-                break;
               }
+              break;
             case ACORN_OTHER:                                   /* C6 nn   */
               if (token2>ACORNOTH_HIGHEST) {
                 if((int32)(token2-ACORN_OTHER) < 0) {           /* Sanity check */
@@ -2490,8 +2490,8 @@ int32 reformat(byte *tp, byte *tokenbuf, int32 ftype) {
                   p = other_token[token-ACORNOTH_LOWEST];
                 }
                 tp++;
-                break;
               }
+              break;
           } /* switch */
         }
       }


### PR DESCRIPTION
Hello,

I have made a few more fixes make `-Wextra` in gcc happier

mainstate.c - the existing behaviour looks fine, I have made it more explicit.

miscprocs.c - kbd_readline() doesn't return a readstate, I'm fairly sure existing behaviour was wrong under error conditions.

tokens.c - I suspect the fall-through will only happen on corrupt BASIC files. We should probably reject the file or warn when the second byte of a two-byte opcode is out of range, rather than ignoring the first byte and treating it as a single byte opcode. However, I don't know if existing BASIC files (perhaps from obscure platforms?) are relying on current behaviour.

I'm not sure about the desired behaviour here, https://github.com/stardot/MatrixBrandy/blame/dev-main/src/mainstate.c#L1732

e43842e6f1f4a62f141074cb938b121d7e1f6899 introduces the clause, so I suspect invoking def_locvar() after falling-through is correct, but I've not convinced myself enough to patch this!